### PR TITLE
fixes #20 option to register route53 cname for vpc endpoints/private links

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -6,6 +6,7 @@
 
 locals {
   instance_alias = "${ var.instance_name == "" ? "waggledance" : format("waggledance-%s",var.instance_name) }"
+  remote_metastore_zone_prefix = "${ var.instance_name == "" ? "remote-metastore" : format("remote-metastore-%s",var.instance_name) }"
 }
 
 data "aws_vpc" "waggledance_vpc" {

--- a/variables.tf
+++ b/variables.tf
@@ -124,3 +124,9 @@ variable "remote_metastores" {
   type        = "list"
   default     = []
 }
+
+variable "enable_remote_metastore_dns" {
+  description = "option to enable creating dns records for remote metastores"
+  type        = "string"
+  default     = ""
+}


### PR DESCRIPTION
so that we can reuse private links from other applications like circustrain to access metastores directly instead of going thru waggle-dance.